### PR TITLE
Feat/#8 다운로드 서비스 구현 완료

### DIFF
--- a/server/src/main/java/com/server/edm/net/MessageTransferManager.java
+++ b/server/src/main/java/com/server/edm/net/MessageTransferManager.java
@@ -6,6 +6,6 @@ import java.util.function.Predicate;
 
 public interface MessageTransferManager {
     Optional<String> requestUntil(final SocketChannel socketChannel, final String request, final Predicate<String> predicate);
-    Optional<String> requestUntil(final SocketChannel socketChannel, final byte[] data, final Predicate<String> predicate, final int tryCount);
+    Optional<String> requestUntil(final SocketChannel socketChannel, final String request, final Predicate<String> predicate, final int tryCount);
 }
 

--- a/server/src/main/java/com/server/edm/service/EdmService.java
+++ b/server/src/main/java/com/server/edm/service/EdmService.java
@@ -5,7 +5,7 @@ import com.server.edm.service.client.ClientManager;
 import java.nio.channels.SocketChannel;
 
 public interface EdmService {
-    boolean register(final String clientReqestServiceName, final SocketChannel socketChannel, final ClientManager clientManager);
+    boolean register(final String clientReqestServiceName, final SocketChannel socketChannel);
 
     void doService();
 }

--- a/server/src/main/java/com/server/edm/service/StreamWebResourceAccessManager.java
+++ b/server/src/main/java/com/server/edm/service/StreamWebResourceAccessManager.java
@@ -1,0 +1,39 @@
+package com.server.edm.service;
+
+import java.io.*;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+
+public class StreamWebResourceAccessManager implements WebResourceAccessManager {
+
+    @Override
+    public BufferedInputStream access(final String path) {
+        return getResourceStream(path);
+    }
+
+    private BufferedInputStream getResourceStream(final String path) {
+        return getInputStream(getConnection(getURL(path)));
+    }
+    private URLConnection getConnection(final URL url) {
+        try {
+            return url.openConnection();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    private URL getURL(final String url) {
+        try {
+            return new URL(url);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    private BufferedInputStream getInputStream(final URLConnection connection) {
+        try {
+            return new BufferedInputStream(connection.getInputStream());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/server/src/main/java/com/server/edm/service/WebResourceAccessManager.java
+++ b/server/src/main/java/com/server/edm/service/WebResourceAccessManager.java
@@ -1,6 +1,7 @@
 package com.server.edm.service;
 
+import java.io.BufferedInputStream;
+
 public interface WebResourceAccessManager {
-    void setUrl(final String url);
-    void start();
+    BufferedInputStream access(final String url);
 }

--- a/server/src/main/java/com/server/edm/service/WebResourceAccessManager.java
+++ b/server/src/main/java/com/server/edm/service/WebResourceAccessManager.java
@@ -1,0 +1,6 @@
+package com.server.edm.service;
+
+public interface WebResourceAccessManager {
+    void setUrl(final String url);
+    void start();
+}

--- a/server/src/main/java/com/server/edm/service/client/BasicClientManager.java
+++ b/server/src/main/java/com/server/edm/service/client/BasicClientManager.java
@@ -1,13 +1,16 @@
 package com.server.edm.service.client;
 
+import com.server.edm.net.DataTransferManager;
 import com.server.edm.net.MessageTransferManager;
 import com.server.edm.service.EdmService;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.nio.channels.SocketChannel;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class BasicClientManager implements ClientManager {
     private final Set<Client> clients = new HashSet<>();
@@ -26,6 +29,14 @@ public class BasicClientManager implements ClientManager {
     public void register(EdmService edmService, SocketChannel socketChannel) {
         final Client client = createClient(edmService, socketChannel);
         clients.add(client);
+    }
+
+    @Override
+    public Set<SocketChannel> getChannels(final EdmService edmService) {
+        return clients.stream()
+                .filter(client -> client.edmService.equals(edmService))
+                .map(client -> client.socketChannel)
+                .collect(Collectors.toSet());
     }
 
     /**

--- a/server/src/main/java/com/server/edm/service/client/ClientManager.java
+++ b/server/src/main/java/com/server/edm/service/client/ClientManager.java
@@ -2,12 +2,15 @@ package com.server.edm.service.client;
 
 import com.server.edm.service.EdmService;
 
+import java.io.BufferedInputStream;
 import java.nio.channels.SocketChannel;
+import java.util.Set;
 
 /**
  * 서비스에 연결된 모든 사용자를 관리
  */
 public interface ClientManager {
     void register(EdmService edmService, SocketChannel socketChannel);
+    Set<SocketChannel> getChannels(EdmService edmService);
     void drop(SocketChannel socketChannel);
 }

--- a/server/src/main/java/com/server/edm/service/distribute/FileDistributingManager.java
+++ b/server/src/main/java/com/server/edm/service/distribute/FileDistributingManager.java
@@ -1,0 +1,9 @@
+package com.server.edm.service.distribute;
+
+import java.io.BufferedInputStream;
+import java.nio.channels.SocketChannel;
+import java.util.Set;
+
+public interface FileDistributingManager {
+    void distribute(Set<SocketChannel> channels, BufferedInputStream fileInputStream, String fileName);
+}

--- a/server/src/main/java/com/server/edm/service/downlaod/DownLoadService.java
+++ b/server/src/main/java/com/server/edm/service/downlaod/DownLoadService.java
@@ -3,8 +3,12 @@ package com.server.edm.service.downlaod;
 import com.server.edm.service.EdmService;
 import com.server.edm.service.WebResourceAccessManager;
 import com.server.edm.service.client.ClientManager;
+import com.server.edm.service.distribute.FileDistributingManager;
+import com.server.edm.ui.DownloadServiceUI;
 
+import java.io.BufferedInputStream;
 import java.nio.channels.SocketChannel;
+import java.util.Set;
 
 /**
  * Download Service v1.0
@@ -13,9 +17,15 @@ import java.nio.channels.SocketChannel;
 public class DownLoadService implements EdmService {
     private static final String DOWNLOAD = "download";
     private final ClientManager clientManager;
+    private final WebResourceAccessManager webResourceAccessManager;
+    private final DownloadServiceUI downloadServiceUI;
+    private final FileDistributingManager fileDistributingManager;
 
-    public DownLoadService(final ClientManager clientManager) {
+    public DownLoadService(final ClientManager clientManager, final WebResourceAccessManager webResourceAccessManager, final DownloadServiceUI downloadServiceUI, final FileDistributingManager fileDistributingManager) {
         this.clientManager = clientManager;
+        this.webResourceAccessManager = webResourceAccessManager;
+        this.downloadServiceUI = downloadServiceUI;
+        this.fileDistributingManager = fileDistributingManager;
     }
 
     @Override
@@ -30,7 +40,13 @@ public class DownLoadService implements EdmService {
     @Override
     public void doService() {
         // 서버 사용자로부터 어떤 파일을 다운로드 받을지 지정하는 로직
-        // 웹 url 을 입력받아
+        final String url = downloadServiceUI.getUrl();
+        final String fileName = downloadServiceUI.getFileName();
+
+        final BufferedInputStream inputStream = webResourceAccessManager.access(url);
+        final Set<SocketChannel> channels = clientManager.getChannels(this);
+
+        fileDistributingManager.distribute(channels, inputStream, fileName);
     }
 
     @Override

--- a/server/src/main/java/com/server/edm/service/downlaod/DownLoadService.java
+++ b/server/src/main/java/com/server/edm/service/downlaod/DownLoadService.java
@@ -1,15 +1,25 @@
 package com.server.edm.service.downlaod;
 
 import com.server.edm.service.EdmService;
+import com.server.edm.service.WebResourceAccessManager;
 import com.server.edm.service.client.ClientManager;
 
 import java.nio.channels.SocketChannel;
 
+/**
+ * Download Service v1.0
+ * 클라이언트가 접속하고 나면, 후에 서버가 어떤 파일을 웹으로부터 다운로드 받을지 정하는 방식
+ */
 public class DownLoadService implements EdmService {
     private static final String DOWNLOAD = "download";
+    private final ClientManager clientManager;
+
+    public DownLoadService(final ClientManager clientManager) {
+        this.clientManager = clientManager;
+    }
 
     @Override
-    public boolean register(final String clientRequestServiceName, final SocketChannel socketChannel, final ClientManager clientManager) {
+    public boolean register(final String clientRequestServiceName, final SocketChannel socketChannel) {
         if (clientRequestServiceName.equals(DOWNLOAD)) {
             clientManager.register(this, socketChannel);
             return true;
@@ -19,6 +29,8 @@ public class DownLoadService implements EdmService {
 
     @Override
     public void doService() {
+        // 서버 사용자로부터 어떤 파일을 다운로드 받을지 지정하는 로직
+        // 웹 url 을 입력받아
     }
 
     @Override

--- a/server/src/main/java/com/server/edm/service/downlaod/distribute/BasicFileDistributingManager.java
+++ b/server/src/main/java/com/server/edm/service/downlaod/distribute/BasicFileDistributingManager.java
@@ -1,0 +1,55 @@
+package com.server.edm.service.downlaod.distribute;
+
+import com.server.edm.net.DataTransferManager;
+import com.server.edm.net.MessageTransferManager;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.nio.channels.SocketChannel;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ *
+ */
+public class BasicFileDistributingManager implements FileDistributingManager {
+    static final int BUFFER_SIZE = 1024;
+    private final MessageTransferManager messageTransferManager;
+    private final DataTransferManager dataTransferManager;
+     static final String START_DOWNLOAD = "START DOWNLOAD";
+     static final String OK_SIGN = "OK";
+
+    public BasicFileDistributingManager(MessageTransferManager messageTransferManager, DataTransferManager dataTransferManager) {
+        this.messageTransferManager = messageTransferManager;
+        this.dataTransferManager = dataTransferManager;
+    }
+
+    @Override
+    public void distribute(Set<SocketChannel> channels, BufferedInputStream fileInputStream, String fileName) {
+        final Set<SocketChannel> readyChannels = readyClient(channels, fileName);
+        final byte[] buffer = new byte[BUFFER_SIZE];
+        int byteCount = 0;
+        try {
+            while ((byteCount = fileInputStream.read(buffer)) != -1) {
+                this.sendToAllChannels(readyChannels, buffer, byteCount);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private Set<SocketChannel> readyClient(final Set<SocketChannel> channels, final String fileName) {
+        final String message = START_DOWNLOAD + ":" + fileName;
+        return channels.parallelStream()
+                .filter(socketChannel -> messageTransferManager.request(
+                socketChannel,
+                message,
+                result -> result.equals(OK_SIGN))
+        ).collect(Collectors.toSet());
+    }
+
+    private void sendToAllChannels(final Set<SocketChannel> channels, final byte[] bytes, final int byteCount) {
+        channels.parallelStream()
+                .forEach(socketChannel -> dataTransferManager.send(socketChannel, bytes, byteCount));
+    }
+}

--- a/server/src/main/java/com/server/edm/service/downlaod/distribute/FileDistributingManager.java
+++ b/server/src/main/java/com/server/edm/service/downlaod/distribute/FileDistributingManager.java
@@ -1,4 +1,4 @@
-package com.server.edm.service.distribute;
+package com.server.edm.service.downlaod.distribute;
 
 import java.io.BufferedInputStream;
 import java.nio.channels.SocketChannel;

--- a/server/src/main/java/com/server/edm/service/stream/StreamingService.java
+++ b/server/src/main/java/com/server/edm/service/stream/StreamingService.java
@@ -1,15 +1,21 @@
 package com.server.edm.service.stream;
 
 import com.server.edm.service.EdmService;
+import com.server.edm.service.WebResourceAccessManager;
 import com.server.edm.service.client.ClientManager;
 
 import java.nio.channels.SocketChannel;
 
 public class StreamingService implements EdmService{
     private static final String STREAMING = "stream";
+    private final ClientManager clientManager;
+
+    public StreamingService(final ClientManager clientManager) {
+        this.clientManager = clientManager;
+    }
 
     @Override
-    public boolean register(final String clientReqestServiceName, final SocketChannel socketChannel, final ClientManager clientManager) {
+    public boolean register(final String clientReqestServiceName, final SocketChannel socketChannel) {
         if (clientReqestServiceName.equals(STREAMING)) {
             // 서비스에 해당 연결을 등록하는 로직
             clientManager.register(this, socketChannel);

--- a/server/src/test/java/com/server/edm/distribute/StreamConnectionDistributorTest.java
+++ b/server/src/test/java/com/server/edm/distribute/StreamConnectionDistributorTest.java
@@ -2,20 +2,59 @@ package com.server.edm.distribute;
 
 import com.server.edm.net.MessageTransferManager;
 import com.server.edm.service.EdmService;
+import com.server.edm.service.StreamWebResourceAccessManager;
+import com.server.edm.service.WebResourceAccessManager;
+import com.server.edm.service.distribute.FileDistributingManager;
 import com.server.edm.service.downlaod.DownLoadService;
 import com.server.edm.service.client.ClientManager;
 import com.server.edm.service.stream.StreamingService;
+import com.server.edm.ui.DownloadServiceUI;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.nio.channels.SocketChannel;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 
 class StreamConnectionDistributorTest {
     private StreamConnectionDistributor streamConnectionDistributor;
+    /**
+     * mock
+     */
+    private DownloadServiceUI downloadServiceUI = new DownloadServiceUI() {
+        @Override
+        public String getUrl() {
+            return null;
+        }
+
+        @Override
+        public String getFileName() {
+            return null;
+        }
+    }
+;
+    /**
+     * mock
+     */
+    private FileDistributingManager fileDistributingManager = new FileDistributingManager() {
+        @Override
+        public void distribute(Set<SocketChannel> channels, BufferedInputStream fileInputStream, String fileName) {
+
+        }
+    };
+    /**
+     * mock
+     */
+    private WebResourceAccessManager webResourceAccessManager = new WebResourceAccessManager() {
+        @Override
+        public BufferedInputStream access(String url) {
+            return null;
+        }
+    };
 
     /**
      * Mock
@@ -27,11 +66,16 @@ class StreamConnectionDistributorTest {
         }
 
         @Override
+        public Set<SocketChannel> getChannels(EdmService edmService) {
+            return null;
+        }
+
+        @Override
         public void drop(SocketChannel socketChannel) {
 
         }
     };
-    private EdmService downloadService = new DownLoadService(clientManager);
+    private EdmService downloadService = new DownLoadService(clientManager, webResourceAccessManager, downloadServiceUI, fileDistributingManager);
     private EdmService streamingService = new StreamingService(clientManager);
     /**
      * Mock
@@ -47,7 +91,7 @@ class StreamConnectionDistributorTest {
             }
 
             @Override
-            public Optional<String> requestUntil(SocketChannel socketChannel, byte[] data, Predicate<String> predicate, int tryCount) {
+            public Optional<String> requestUntil(SocketChannel socketChannel, String data, Predicate<String> predicate, int tryCount) {
                 // not used
                 return Optional.of(result);
             }

--- a/server/src/test/java/com/server/edm/distribute/StreamConnectionDistributorTest.java
+++ b/server/src/test/java/com/server/edm/distribute/StreamConnectionDistributorTest.java
@@ -31,8 +31,8 @@ class StreamConnectionDistributorTest {
 
         }
     };
-    private EdmService downloadService = new DownLoadService();
-    private EdmService streamingService = new StreamingService();
+    private EdmService downloadService = new DownLoadService(clientManager);
+    private EdmService streamingService = new StreamingService(clientManager);
     /**
      * Mock
      */

--- a/server/src/test/java/com/server/edm/service/StreamWebResourceAccessManagerTest.java
+++ b/server/src/test/java/com/server/edm/service/StreamWebResourceAccessManagerTest.java
@@ -1,0 +1,21 @@
+package com.server.edm.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StreamWebResourceAccessManagerTest {
+    private WebResourceAccessManager accessManager = new StreamWebResourceAccessManager();
+
+    @Test
+    void successfulAccessTest() {
+        BufferedInputStream inputStream = accessManager.access("https://www.google.com/imgres?q=사진&imgurl=https%3A%2F%2Fcdn.travie.com%2Fnews%2Fphoto%2Ffirst%2F201710%2Fimg_19975_1.jpg&imgrefurl=https%3A%2F%2Fwww.travie.com%2Fnews%2FarticleView.html%3Fidxno%3D19975&docid=D696xPT19OV0eM&tbnid=-MQcOiDkucl80M&vet=12ahUKEwi1qYXt2qWGAxUfoK8BHbR_A6IQM3oECB0QAA..i&w=800&h=538&hcb=2&ved=2ahUKEwi1qYXt2qWGAxUfoK8BHbR_A6IQM3oECB0QAA");
+        Assertions.assertDoesNotThrow(() -> inputStream.read());
+    }
+
+
+}

--- a/server/src/test/java/com/server/edm/service/client/BasicClientManagerTest.java
+++ b/server/src/test/java/com/server/edm/service/client/BasicClientManagerTest.java
@@ -36,7 +36,7 @@ class BasicClientManagerTest {
 
     @Test
     void duplicateNameInSameServiceTest() throws IOException {
-        final EdmService edmService = new DownLoadService();
+        final EdmService edmService = new DownLoadService(basicClientManager);
         final String name = "tester";
         init(modifyClientResponse(name));
 
@@ -49,8 +49,8 @@ class BasicClientManagerTest {
 
     @Test
     void duplicateNameInDifferentServiceTest() throws IOException {
-        final EdmService edmService1 = new DownLoadService();
-        final EdmService edmService2 = new DownLoadService();
+        final EdmService edmService1 = new DownLoadService(basicClientManager);
+        final EdmService edmService2 = new DownLoadService(basicClientManager);
         final String name = "tester";
         init(modifyClientResponse(name));
 

--- a/server/src/test/java/com/server/edm/service/client/BasicClientManagerTest.java
+++ b/server/src/test/java/com/server/edm/service/client/BasicClientManagerTest.java
@@ -14,6 +14,24 @@ class BasicClientManagerTest {
     private BasicClientManager basicClientManager;
     private MessageTransferManager messageTransferManager;
     private Encoder encoder = new UTFEncoder();
+    private EdmService createMockService(final String serviceName) {
+        return new EdmService() {
+            @Override
+            public boolean register(String clientReqestServiceName, SocketChannel socketChannel) {
+                return false;
+            }
+
+            @Override
+            public void doService() {
+
+            }
+
+            @Override
+            public String toString() {
+                return serviceName;
+            }
+        };
+    }
 
     void init(final DataTransferManager dataTransferManager) {
         this.messageTransferManager = new BasicMessageTransferManager(dataTransferManager, encoder);
@@ -36,7 +54,7 @@ class BasicClientManagerTest {
 
     @Test
     void duplicateNameInSameServiceTest() throws IOException {
-        final EdmService edmService = new DownLoadService(basicClientManager);
+        final EdmService edmService = createMockService("tester");
         final String name = "tester";
         init(modifyClientResponse(name));
 
@@ -49,9 +67,9 @@ class BasicClientManagerTest {
 
     @Test
     void duplicateNameInDifferentServiceTest() throws IOException {
-        final EdmService edmService1 = new DownLoadService(basicClientManager);
-        final EdmService edmService2 = new DownLoadService(basicClientManager);
         final String name = "tester";
+        final EdmService edmService2 = createMockService("testService");
+        final EdmService edmService1 = createMockService("testService");
         init(modifyClientResponse(name));
 
         final SocketChannel socketChannel1 = SocketChannel.open();
@@ -59,5 +77,16 @@ class BasicClientManagerTest {
 
         basicClientManager.register(edmService1, socketChannel1);
         basicClientManager.register(edmService2, socketChannel2);
+    }
+
+    @Test
+    void getCorrectChannelsTest() throws IOException {
+        final EdmService edmService = createMockService("tester");
+        final String name = "tester";
+        init(modifyClientResponse(name));
+        final SocketChannel socketChannel = SocketChannel.open();
+        basicClientManager.register(edmService, socketChannel);
+
+        Assertions.assertEquals(basicClientManager.getChannels(edmService).size(), 1);
     }
 }

--- a/server/src/test/java/com/server/edm/service/downlaod/distribute/BasicFileDistributingManagerTest.java
+++ b/server/src/test/java/com/server/edm/service/downlaod/distribute/BasicFileDistributingManagerTest.java
@@ -1,0 +1,96 @@
+package com.server.edm.service.downlaod.distribute;
+
+import com.server.edm.net.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.channels.SocketChannel;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+class BasicFileDistributingManagerTest {
+    private MessageTransferManager messageTransferManager;
+    private DataTransferManager dataTransferManager;
+    private Encoder encoder = new UTFEncoder();
+
+    private AtomicInteger resultCounter = new AtomicInteger();
+    void initMessageTransferManager() {
+        this.messageTransferManager = new BasicMessageTransferManager(dataTransferManager, encoder);
+    }
+    void modifyClientResponse(final String clientResponse) {
+        this.dataTransferManager = new DataTransferManager() {
+            @Override
+            public byte[] sendAndRecieve(SocketChannel socketChannel, byte[] data, int byteCount) {
+                // 성공 가정
+                return encoder.encode(clientResponse);
+            }
+
+            @Override
+            public void send(SocketChannel socketChannel, byte[] data, int byteCount) {
+                // 클라이언트에게 데이터 전송이 되는지 확인
+                resultCounter.incrementAndGet();
+            }
+        };
+    }
+
+    void initResultCounter() {
+        resultCounter = new AtomicInteger();
+    }
+
+    @Test
+    void clientResponseIsOK() {
+        initResultCounter();
+        modifyClientResponse(BasicFileDistributingManager.OK_SIGN);
+        initMessageTransferManager();
+        final FileDistributingManager fileDistributingManager = new BasicFileDistributingManager(messageTransferManager, dataTransferManager);
+
+
+        final SocketChannel socketChannel1;
+        final SocketChannel socketChannel2;
+        try {
+            socketChannel1 = SocketChannel.open();
+            socketChannel2 = SocketChannel.open();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        Set<SocketChannel> channels = Set.of(socketChannel1, socketChannel2);
+        // test data
+        final byte[] data = {1, 2, 34, 5};
+        final BufferedInputStream bufferedInputStream = new BufferedInputStream(new ByteArrayInputStream(data));
+
+
+        fileDistributingManager.distribute(channels, bufferedInputStream, "test");
+
+        Assertions.assertEquals(resultCounter.get(), 2);
+    }
+
+    @Test
+    void clientResponseIsNotOK() {
+        initResultCounter();
+        modifyClientResponse("maybe not ok?");
+        initMessageTransferManager();
+        final FileDistributingManager fileDistributingManager = new BasicFileDistributingManager(messageTransferManager, dataTransferManager);
+
+
+        final SocketChannel socketChannel1;
+        final SocketChannel socketChannel2;
+        try {
+            socketChannel1 = SocketChannel.open();
+            socketChannel2 = SocketChannel.open();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        Set<SocketChannel> channels = Set.of(socketChannel1, socketChannel2);
+        // test data
+        final byte[] data = {1, 2, 34, 5};
+        final BufferedInputStream bufferedInputStream = new BufferedInputStream(new ByteArrayInputStream(data));
+
+
+        fileDistributingManager.distribute(channels, bufferedInputStream, "test");
+        Assertions.assertEquals(resultCounter.get(), 0);
+    }
+            
+}


### PR DESCRIPTION
계획대로, 서버측에서 먼저 다운로드 객체를 만들어두면, 클라이언트가 이에 접속하여 대기한다. 
이후에, 서버측에서 서비스를 시작하면, 모든 클라이언트에게로 파일 분배가 시작된다. 


문제점 
1.  클라이언트는 파일 다운로드가 완료되기 전까지 어떤 파일이 다운로드되고 있는지 모른다.
2. 한번의 접속에 하나의 파일만 다운받을 수 있다. 
